### PR TITLE
add explicit dependency on lzop to RPM .spec file

### DIFF
--- a/snebu.spec
+++ b/snebu.spec
@@ -8,6 +8,7 @@ License:	GPLv3
 URL:		http://www.snebu.com
 Source0:	snebu-%{version}.tar.gz
 Patch1:		Makefile-Fedora.patch
+Requires:	lzop
 
 
 %description


### PR DESCRIPTION
Just to make sure /usr/bin/lzop is available
