### PR TITLE
Fixed getopt: unrecognized option '--remote-user'

### DIFF
--- a/snebu-client
+++ b/snebu-client
@@ -32,7 +32,7 @@ process_cmdline()
     else
 	verbose=0
     fi
-    if ! args=("$(getopt -l "config:,name:,remote-client:,backup-server:,backup-user:,retention:,date:,force-full,changedir:,exclude:,xmatch:,graft:,plugin:,verbose,quiet,help,sudo:,encryption-key:,decrypt,nodecrypt" -o "c:n:r:d:fqvC:x:m:hk:" -- "$@")")
+    if ! args=("$(getopt -l "config:,name:,remote-client:,backup-server:,backup-user:,remote-user:,retention:,date:,force-full,changedir:,exclude:,xmatch:,graft:,plugin:,verbose,quiet,help,sudo:,encryption-key:,decrypt,nodecrypt" -o "c:n:r:d:fqvC:x:m:hk:" -- "$@")")
     then
         usage target
         exit 1


### PR DESCRIPTION
Using the following syntax the --remote-user option is not parsed correctly in the snebu-client.

snebu@bkupsvr1:~$ snebu-client backup --remote-client bosshost1 --remote-user root --sudo svs-backup